### PR TITLE
Add validation for blogpost create

### DIFF
--- a/assets/scripts/blog/blog-events.js
+++ b/assets/scripts/blog/blog-events.js
@@ -10,6 +10,9 @@ const onNewPost = function (event) {
   event.preventDefault();
   let data = getFormFields(this);
   console.log("data is ", data);
+  if(!data.title || !data.content) {
+    return;
+  }
   api.newPost(data)
     .then(ui.success)
     .catch(ui.failure);


### PR DESCRIPTION
Validated blogpost create to make the create button
unclickable if either title or content is empty.